### PR TITLE
Replace logo with image and add dark mode to pricing

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,13 +88,17 @@ const Header = () => {
     >
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo */}
-        <Link to="/" className="flex items-center space-x-3">
-          <img
-            src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
-            alt="COFTECH"
-            className="w-14 h-14 object-contain"
-          />
-          <span className="text-xl font-bold gradient-text">COFTECH</span>
+        <Link to="/" className="flex items-center space-x-2 group">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-gradient-to-br from-blue-500 to-cyan-500 p-1 transition-transform group-hover:scale-105">
+            <img
+              src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
+              alt="COFTECH"
+              className="w-full h-full object-contain"
+            />
+          </div>
+          <span className="text-2xl font-bold gradient-text tracking-wide">
+            COFTECH
+          </span>
         </Link>
 
         {/* Desktop Navigation */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,17 +88,14 @@ const Header = () => {
     >
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo */}
-        <Link to="/" className="flex items-center space-x-2 group">
-          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-white shadow-sm p-1 transition-transform group-hover:scale-105">
+        <Link to="/" className="flex items-center group">
+          <div className="flex items-center justify-center w-14 h-14 rounded-lg bg-white shadow-sm p-2 transition-transform group-hover:scale-105">
             <img
               src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
               alt="COFTECH"
               className="w-full h-full object-contain"
             />
           </div>
-          <span className="text-2xl font-bold gradient-text tracking-wide">
-            COFTECH
-          </span>
         </Link>
 
         {/* Desktop Navigation */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -92,7 +92,7 @@ const Header = () => {
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
             alt="COFTECH"
-            className="w-12 h-12 object-contain"
+            className="w-24 h-24 object-contain"
           />
           <span className="text-xl font-bold gradient-text">COFTECH</span>
         </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,11 +88,11 @@ const Header = () => {
     >
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo */}
-        <Link to="/" className="flex items-center space-x-2">
+        <Link to="/" className="flex items-center space-x-3">
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
             alt="COFTECH"
-            className="w-24 h-24 object-contain"
+            className="w-14 h-14 object-contain"
           />
           <span className="text-xl font-bold gradient-text">COFTECH</span>
         </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -89,9 +89,11 @@ const Header = () => {
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo */}
         <Link to="/" className="flex items-center space-x-2">
-          <div className="w-8 h-8 bg-gradient-ai rounded-lg flex items-center justify-center">
-            <Bot className="w-5 h-5 text-white" />
-          </div>
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
+            alt="COFTECH"
+            className="w-8 h-8 object-contain"
+          />
           <span className="text-xl font-bold gradient-text">COFTECH</span>
         </Link>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -89,13 +89,11 @@ const Header = () => {
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo */}
         <Link to="/" className="flex items-center group">
-          <div className="flex items-center justify-center w-14 h-14 rounded-lg bg-white shadow-sm p-2 transition-transform group-hover:scale-105">
-            <img
-              src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
-              alt="COFTECH"
-              className="w-full h-full object-contain"
-            />
-          </div>
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
+            alt="COFTECH"
+            className="w-16 h-16 object-contain transition-transform group-hover:scale-105"
+          />
         </Link>
 
         {/* Desktop Navigation */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -92,7 +92,7 @@ const Header = () => {
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
             alt="COFTECH"
-            className="w-8 h-8 object-contain"
+            className="w-12 h-12 object-contain"
           />
           <span className="text-xl font-bold gradient-text">COFTECH</span>
         </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -89,7 +89,7 @@ const Header = () => {
       <div className="container mx-auto px-4 h-16 flex items-center justify-between">
         {/* Logo */}
         <Link to="/" className="flex items-center space-x-2 group">
-          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-gradient-to-br from-blue-500 to-cyan-500 p-1 transition-transform group-hover:scale-105">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-white shadow-sm p-1 transition-transform group-hover:scale-105">
             <img
               src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
               alt="COFTECH"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -86,13 +86,13 @@ const Header = () => {
           : "bg-transparent",
       )}
     >
-      <div className="container mx-auto px-4 h-16 flex items-center justify-between">
+      <div className="container mx-auto px-4 h-20 flex items-center justify-between">
         {/* Logo */}
         <Link to="/" className="flex items-center group">
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F29c0a7297fc14c1d91748176ea31f04a%2F8b1472ec59ff4eca88d17af94001371f?format=webp&width=800"
             alt="COFTECH"
-            className="w-16 h-16 object-contain transition-transform group-hover:scale-105"
+            className="w-20 h-20 object-contain transition-transform group-hover:scale-105"
           />
         </Link>
 

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -61,7 +61,7 @@ const Pricing = () => {
 
       <div className="pt-20">
         {/* Hero Section */}
-        <section className="py-20 bg-gradient-to-br from-blue-50 via-blue-100 to-cyan-50">
+        <section className="py-20 bg-gradient-to-br from-blue-50 via-blue-100 to-cyan-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
           <div className="container mx-auto px-4 text-center">
             <h1 className="text-5xl md:text-6xl font-bold mb-6 gradient-text">
               AI Services Pricing


### PR DESCRIPTION
This pull request makes two main changes:

**Header Component:**
- Increased header height from h-16 to h-20
- Replaced Bot icon and text logo with an image logo from Builder.io CDN
- Added hover scale effect with group-hover:scale-105 transition
- Updated logo container styling to use group class

**Pricing Page:**
- Added dark mode gradient background classes to hero section
- Extended existing gradient from blue/cyan to include dark gray variants for dark mode

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fe22c3f9311241a8b75d0acece735abf/swoosh-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe22c3f9311241a8b75d0acece735abf</projectId>-->
<!--<branchName>swoosh-space</branchName>-->